### PR TITLE
Add js_eqRef, eqRef, and instance Eq (JSRef a)

### DIFF
--- a/GHCJS/Prim.hs
+++ b/GHCJS/Prim.hs
@@ -19,6 +19,7 @@ module GHCJS.Prim ( JSRef(..)
                   , jsNull
                   , getProp
                   , getProp'
+                  , eqRef
 #endif
                   ) where
 
@@ -102,6 +103,10 @@ jsNull :: JSRef a
 jsNull = js_null
 {-# INLINE jsNull #-}
 
+eqRef :: JSRef a -> JSRef b -> Bool
+eqRef x y = js_eqRef x y
+{-# INLINE eqRef #-}
+
 getProp :: JSRef a -> String -> IO (JSRef b)
 getProp o p = js_getProp o (unsafeCoerce $ seqList p)
 {-# INLINE getProp #-}
@@ -147,6 +152,9 @@ foreign import javascript unsafe "$r = $1;"
 
 foreign import javascript unsafe "$r = null;"
   js_null :: JSRef a
+
+foreign import javascript unsafe "$1 === $2"
+  js_eqRef :: JSRef a -> JSRef b -> Bool
 
 foreign import javascript unsafe "$1[h$fromHsString($2)]"
   js_getProp :: JSRef a -> Double -> IO (JSRef b)


### PR DESCRIPTION
~~This pulls in @ryantrinkle's commit on master into the ghc-7.10 branch.~~

https://github.com/ghcjs/ghcjs-base/commit/bcd6988b07d99e7984de92857e87593e882642d3 removed `js_eqRef` and `eqRef`, but they weren't added back in [ghcjs-prim/ghc-7.10](https://github.com/ghcjs/ghcjs-prim/tree/ghc-7.10).

See: https://github.com/NixOS/nixpkgs/issues/7768
